### PR TITLE
Add bootstrap-sprockets again

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require bootstrap-sprockets
 //= require bootstrapValidator.min
 //= require_tree .
 


### PR DESCRIPTION
Bootstrap-sprockets were removed in #6, but they are needed to close the flash messages. 
